### PR TITLE
Adding temperature information to thermal image

### DIFF
--- a/src/OptrisColorconvert.cpp
+++ b/src/OptrisColorconvert.cpp
@@ -117,6 +117,13 @@ namespace optris_drivers2
     sensor_msgs::msg::CameraInfo camera_info = _camera_info_manager.getCameraInfo();
     camera_info.header = img.header;
     _pubThermal.publish(img, camera_info);
+    //get the max and min temperature
+    int radius = 3;
+    if(img.width <9 || img.height<9) radius = 2;
+    evo::ExtremalRegion minRegion;
+    evo::ExtremalRegion maxRegion;
+    _iBuilder.getMinMaxRegion(radius, &minRegion, &maxRegion);
+    RCLCPP_INFO(get_logger(), "Max temp: %f degree, Min temp: %f degree", maxRegion.t, minRegion.t);
   }
 
   void OptrisColorconvert::onVisibleDataReceive(const sensor_msgs::msg::Image::ConstSharedPtr & image)

--- a/src/OptrisImager.cpp
+++ b/src/OptrisImager.cpp
@@ -118,7 +118,7 @@ void OptrisImager::onThermalFrame(unsigned short* image, unsigned int w, unsigne
 {
   (void) arg;
 
-  RCLCPP_INFO(get_logger(), "onThermalFrame");
+  //RCLCPP_INFO(get_logger(), "onThermalFrame");
   memcpy(&_thermal_image.data[0], image, w * h * sizeof(*image));
 
   _thermal_image.header.frame_id = "";


### PR DESCRIPTION
It would be more convenient for seeing the temperature information when did the recording
![image](https://github.com/evocortex/optris_drivers2/assets/134256572/98007f1e-aada-4d2f-b60c-a7ac90b0e3a3)
